### PR TITLE
Moved the interrupt vector table to flash and corrected the timer to …

### DIFF
--- a/application/src/blink.cpp
+++ b/application/src/blink.cpp
@@ -59,7 +59,7 @@ int main ()
 //			count = 0;
 //			gpio->set( Gpio::pin21 );
 //		}
-//		timer2->waitFor1MsTimeOut();
+//		timer1->waitFor1MsTimeOut();
 //		count++;
 	}
 	return 0;

--- a/driver/src/interrupt.cpp
+++ b/driver/src/interrupt.cpp
@@ -97,7 +97,7 @@ void Interrupt::defaultHandler()
 /*** Interrupt Vector Table ***/
 extern "C"
 {
-	Interrupt::handlerType interruptVectorTable[Interrupt::numberOfSources] = {
+	extern const Interrupt::handlerType interruptVectorTable[Interrupt::numberOfSources] = {
 		/* notUsed  */ Interrupt::defaultHandler,
 		/* watchdog */ Interrupt::defaultHandler,
 		/* rtc      */ Interrupt::defaultHandler,


### PR DESCRIPTION
…be used when polling the timer rather than using interrupt, in the code that is commented out in blink.cpp